### PR TITLE
Fix issue with multiple spaces in name string. Also bumped Version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ and 'William Frederick Halsey').
   1.0
   >>> name_tools.match('Bob Dole', 'Dole, Bob')
   0.98
+  >>> name_tools.match("michaeL StepHens", "MichaEl  StePhens")
+  0.98
   >>> name_tools.match("Mr. X", "X")
   0.95
   >>> name_tools.match('Jeff Tweedy', 'J Tweedy')

--- a/name_tools/__init__.py
+++ b/name_tools/__init__.py
@@ -2,4 +2,4 @@ from .match import match
 from .split import split, canonicalize
 from .forms import name_forms
 
-__version__ = "0.1.3"
+__version__ = "0.1.5"

--- a/name_tools/match.py
+++ b/name_tools/match.py
@@ -68,6 +68,10 @@ def match(name1, name2):
     True
     >>> abs(match("michaeL StepHens", "MichaEl StePhens") - 0.98) < 0.001
     True
+    >>> abs(match("michaeL StepHens", "MichaEl  StePhens") - 0.98) < 0.001
+    True
+    >>> abs(match("michaeL  StepHens", "MichaEl StePhens") - 0.98) < 0.001
+    True
     >>> abs(match("Michael J. Stephens", "Michael J Stephens") - 0.98) < 0.001
     True
     >>> abs(match("Michael Stephens", "Mr. Michael Stephens") - 0.95) < 0.001
@@ -92,6 +96,9 @@ def match(name1, name2):
 
     if not name1.strip() or not name2.strip():
         return 0.0
+
+    name1 = re.sub('  +', ' ', name1)
+    name2 = re.sub('  +', ' ', name2)
 
     s1 = set()
     s2 = set()


### PR DESCRIPTION
Fixes an issue when multiple spaces are in a name. Example:

name_tools.match("michaeL StepHens", "MichaEl  StePhens")
Result:
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/name_tools/match.py", line 103, in match
    n2 = func(n2)
  File "/usr/local/lib/python2.7/site-packages/name_tools/match.py", line 19, in middle_initials
    name += " " + part[0]
IndexError: string index out of range
